### PR TITLE
Experimenting with a proxy

### DIFF
--- a/example/public/index.html
+++ b/example/public/index.html
@@ -9,8 +9,9 @@
     <link rel="icon" type="image/png" href="/favicon.png" />
 
     <script defer src="/bundle.js"></script>
-    <hello-world message="World"></hello-world>
   </head>
 
-  <body></body>
+  <body>
+    <hello-world message="World"></hello-world>
+  </body>
 </html>

--- a/example/src/hello-world.js
+++ b/example/src/hello-world.js
@@ -1,5 +1,6 @@
-class HelloWorld extends HTMLElement {
+/* eslint-env browser */
 
+class HelloWorld extends HTMLElement {
   constructor() {
     super()
     this.attachShadow({ mode: 'open' })
@@ -9,7 +10,7 @@ class HelloWorld extends HTMLElement {
   }
 
   static get observedAttributes() {
-    return [ 'message' ]
+    return ['message']
   }
 
   connectedCallback() {
@@ -40,11 +41,76 @@ class HelloWorld extends HTMLElement {
       <h1>Hello ${this.message}</h1>
     `
   }
-
 }
 
-//// the if condition doesnt work 
-///  when you change/update hello-world component
-if (!customElements.get('hello-world')) {
-  customElements.define('hello-world', HelloWorld)
+const tag = 'hello-world'
+
+if (customElements.get(tag)) {
+  const HelloWorldProxy = customElements.get(tag)
+
+  // we can't change HelloWorldProxy's constructor (hence constructor's proto)
+  // because it is an ES class (can we?)
+  //
+  // so instead, we'll store it, and change the prototype of each existing
+  // instances and each new instances (that we can)
+  //
+  HelloWorldProxy.current = HelloWorld.prototype
+
+  // rerender instances
+  HelloWorldProxy.instances.forEach(instance => {
+    Object.setPrototypeOf(instance, HelloWorldProxy.current)
+    //
+    // /!\ we have to know how to trigger a rerender of the component
+    //
+    instance.render()
+  })
+} else {
+  // we cannot redefine a custom element with the same name (can we?), so
+  // instead of exposing the real component class (that will change with HMR),
+  // we're exposing a HMR controlled proxy
+  //
+  // next challenge will be to make this proxy always behave like the _last_
+  // version of a component... and also update state / view of all existing
+  // instances when an update happens
+  //
+  class HelloWorldProxy extends HelloWorld {
+    constructor(...args) {
+      //
+      // /!\ we have to call super before accessing this
+      //
+      // that means the user's new constructor will have run with the wrong
+      // prototype :-/
+      //
+      super(...args)
+
+      // if there's a current, that means the HelloWorld the proxy is extending
+      // is an old version... we need to hijack the prototype with the new one
+      // (it would really be better if we could do that _before_ super is called)
+      if (HelloWorldProxy.current) {
+        Object.setPrototypeOf(this, HelloWorldProxy.current)
+      }
+    }
+
+    connectedCallback() {
+      // register instance, to be able to update it on change
+      HelloWorldProxy.instances.push(this)
+      super.connectedCallback()
+    }
+
+    disconnectedCallback() {
+      const index = HelloWorldProxy.instances.findIndex(this)
+      HelloWorldProxy.instances.splice(index, 1)
+      super.disconnectedCallback()
+    }
+  }
+
+  // a registry for all instances that are created
+  //
+  // HelloWorldProxy will reside in memory, and won't be overwritten when HMR
+  // runs the new file (thanks to the if condition we're in). that means we can
+  // store global state on it.
+  //
+  HelloWorldProxy.instances = []
+
+  customElements.define(tag, HelloWorldProxy)
 }

--- a/example/src/hello-world.js
+++ b/example/src/hello-world.js
@@ -1,8 +1,16 @@
 /* eslint-env browser */
 
 class HelloWorld extends HTMLElement {
-  constructor() {
-    super()
+  // NOTE we cannot have a real constructor, because we cannot replace the
+  // constructor of the HMR proxy (can we?); this means that the constructor
+  // of the first version of the component will run every time a HMR update
+  // happens (so it needs to be empty to avoid problems)
+  //
+  // constructor should be renamed by a code transform in HMR plugin, since
+  // the transformed class does not work without the HMR proxy
+  //
+  _constructor() {
+    // super()
     this.attachShadow({ mode: 'open' })
 
     /// update the value of message
@@ -46,25 +54,26 @@ class HelloWorld extends HTMLElement {
 const tag = 'hello-world'
 
 if (customElements.get(tag)) {
+  // this block runs when the module is re executed after a HMR update
+
+  // we're getting the Proxy that was created when the module was first
+  // executed (in the else block that follows)
   const HelloWorldProxy = customElements.get(tag)
 
-  // we can't change HelloWorldProxy's constructor (hence constructor's proto)
-  // because it is an ES class (can we?)
-  //
-  // so instead, we'll store it, and change the prototype of each existing
-  // instances and each new instances (that we can)
-  //
-  HelloWorldProxy.current = HelloWorld.prototype
-
-  // rerender instances
-  HelloWorldProxy.instances.forEach(instance => {
-    Object.setPrototypeOf(instance, HelloWorldProxy.current)
-    //
-    // /!\ we have to know how to trigger a rerender of the component
-    //
-    instance.render()
-  })
+  HelloWorldProxy.update(HelloWorld)
 } else {
+  // this block runs when the module is first executed (initial load)
+  //
+  // we create a Proxy that we put into the customElements registry, and we
+  // try to make this Proxy behaves all like the last version of its component
+  //
+  // we also need to recompute / rerender all existing instances when a
+  // component is updated through HMR
+  //
+
+  const instances = []
+  let current = HelloWorld.prototype
+
   // we cannot redefine a custom element with the same name (can we?), so
   // instead of exposing the real component class (that will change with HMR),
   // we're exposing a HMR controlled proxy
@@ -73,6 +82,7 @@ if (customElements.get(tag)) {
   // version of a component... and also update state / view of all existing
   // instances when an update happens
   //
+  // class HelloWorldProxy extends Object.getPrototypeOf(HelloWorld) {
   class HelloWorldProxy extends HelloWorld {
     constructor(...args) {
       //
@@ -83,34 +93,49 @@ if (customElements.get(tag)) {
       //
       super(...args)
 
-      // if there's a current, that means the HelloWorld the proxy is extending
-      // is an old version... we need to hijack the prototype with the new one
-      // (it would really be better if we could do that _before_ super is called)
-      if (HelloWorldProxy.current) {
-        Object.setPrototypeOf(this, HelloWorldProxy.current)
+      // hijack this instance's prototype with the current last version
+      if (current !== Object.getPrototypeOf(this)) {
+        Object.setPrototypeOf(this, current)
       }
+
+      return this._constructor(...args)
     }
 
     connectedCallback() {
       // register instance, to be able to update it on change
-      HelloWorldProxy.instances.push(this)
-      super.connectedCallback()
+      instances.push(this)
+      // proxy to the current proto's connectedCallback (we can't call it with
+      // super because it would always go to the first version of HelloWorld)
+      if (current.connectedCallback) {
+        return current.connectedCallback.apply(this, arguments)
+      }
     }
 
     disconnectedCallback() {
-      const index = HelloWorldProxy.instances.findIndex(this)
-      HelloWorldProxy.instances.splice(index, 1)
-      super.disconnectedCallback()
+      const index = instances.findIndex(this)
+      instances.splice(index, 1)
+      if (current.disconnectedCallback) {
+        return current.disconnectedCallback.apply(this, arguments)
+      }
     }
   }
 
-  // a registry for all instances that are created
-  //
-  // HelloWorldProxy will reside in memory, and won't be overwritten when HMR
-  // runs the new file (thanks to the if condition we're in). that means we can
-  // store global state on it.
-  //
-  HelloWorldProxy.instances = []
+  HelloWorldProxy.update = ({ prototype }) => {
+    // we can't change HelloWorldProxy's constructor (hence constructor's proto)
+    // because it is an ES class (can we?)
+    //
+    // so instead, we'll store it, and change the prototype of each existing
+    // instances and each new instances (that we can)
+    //
+    current = prototype
+    instances.forEach(instance => {
+      Object.setPrototypeOf(instance, current)
+      //
+      // /!\ we have to know how to trigger a rerender of the component
+      //
+      instance.render()
+    })
+  }
 
   customElements.define(tag, HelloWorldProxy)
 }


### PR DESCRIPTION
This makes your use case works with HMR, as far as I can tell, but this is limited to this very example. This is by no mean enough to generalize to every possible web components.

It only works because your example component is very simple and, very notably, because it is fully declarative. That is, it is capable of recomputing / updating its whole view as a function of its state:

~~~js
  render() {
    this.shadowRoot.innerHTML = `
      <h1>Hello ${this.message}</h1>
    `
  }
~~~

HMR has to have knowledge of this `render` method to be able to update the view after an update. How could this be solved in a general way that would work for any web component? Or at least the subset we'd want to support? (I don't think any HMR is really capable of supporting non-declarative.)

There are also shortcomings in my current implementation. But that's too technical for now... I've tried to highlight some of the problems in the comments of my code, though.

I'm illiterate in web components, so if you want to take a look, maybe you can have some insights on how this could or should be done.

Also, you can try to complexify this example toward a little more real world use cases, to see the next wave of hurdles that we will encounter. But... go easy on it! I've got a feeling they're gonna come fast.